### PR TITLE
Add GitHub Skills extracurricular activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the **GitHub Skills** extracurricular activity to the school activities signup page, as announced by the principal.

## Changes

- Added "GitHub Skills" to the in-memory activities database in `src/app.py`
  - **Description:** Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program
  - **Schedule:** Mondays and Wednesdays, 3:30 PM - 4:30 PM
  - **Max participants:** 25

## Related Issue

Closes #6